### PR TITLE
Fix build failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ cover/
 eunit.coverdata
 _build/
 rebar.lock
-
+erlang.mk

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,7 @@ dep_emqx_auth_username = git-emqx https://github.com/emqx/emqx-auth-username emq
 
 COVER = true
 
-define dep_fetch_git-emqx
-	git clone -q --depth 1 -b $(call dep_commit,$(1)) -- $(call dep_repo,$(1)) $(DEPS_DIR)/$(call dep_name,$(1)) > /dev/null 2>&1; \
-	cd $(DEPS_DIR)/$(call dep_name,$(1));
-endef
-
+$(shell [ -f erlang.mk ] || curl -s -o erlang.mk https://raw.githubusercontent.com/emqx/erlmk/master/erlang.mk)
 include erlang.mk
 
 app:: rebar.config


### PR DESCRIPTION
Prior to this change, emqx_auth_mongo adopt another stragegy to build
itself. I change the makefile to get erlang.mk hosted on the repo of emqx
on github.

This change fix the build failure