### PR TITLE
refactor: use the dynamic ecpool name instead of ?APP

### DIFF
--- a/src/emqx_acl_mongo.erl
+++ b/src/emqx_acl_mongo.erl
@@ -32,13 +32,13 @@ register_metrics() ->
 check_acl(#{username := <<$$, _/binary>>}, _PubSub, _Topic, _AclResult, _State) ->
     ok;
 
-check_acl(ClientInfo, PubSub, Topic, _AclResult, #{aclquery := AclQuery}) ->
+check_acl(ClientInfo, PubSub, Topic, _AclResult, #{aclquery := AclQuery , pool := Pool}) ->
     #aclquery{collection = Coll, selector = SelectorList} = AclQuery,
     SelectorMapList =
         lists:map(fun(Selector) ->
             maps:from_list(emqx_auth_mongo:replvars(Selector, ClientInfo))
         end, SelectorList),
-    case emqx_auth_mongo:query_multi(Coll, SelectorMapList) of
+    case emqx_auth_mongo:query_multi(Pool, Coll, SelectorMapList) of
         [] -> ok;
         Rows ->
             try match(ClientInfo, Topic, topics(PubSub, Rows)) of

--- a/src/emqx_acl_mongo.erl
+++ b/src/emqx_acl_mongo.erl
@@ -32,8 +32,9 @@ register_metrics() ->
 check_acl(#{username := <<$$, _/binary>>}, _PubSub, _Topic, _AclResult, _State) ->
     ok;
 
-check_acl(ClientInfo, PubSub, Topic, _AclResult, #{aclquery := AclQuery , pool := Pool}) ->
+check_acl(ClientInfo, PubSub, Topic, _AclResult, Env = #{aclquery := AclQuery}) ->
     #aclquery{collection = Coll, selector = SelectorList} = AclQuery,
+    Pool = maps:get(pool, Env, ?APP),
     SelectorMapList =
         lists:map(fun(Selector) ->
             maps:from_list(emqx_auth_mongo:replvars(Selector, ClientInfo))

--- a/src/emqx_auth_mongo.appup.src
+++ b/src/emqx_auth_mongo.appup.src
@@ -1,0 +1,17 @@
+%%-*-: erlang -*-
+{"4.2.1",
+   [
+     {"4.2.0", [
+       {load_module, emqx_auth_mongo_app, brutal_purge, soft_purge, []},
+       {load_module, emqx_auth_mongo, brutal_purge, soft_purge, []},
+       {load_module, emqx_acl_mongo, brutal_purge, soft_purge, [emqx_auth_mongo]}
+     ]}
+   ],
+   [
+     {"4.2.0", [
+       {load_module, emqx_auth_mongo_app, brutal_purge, soft_purge, []},
+       {load_module, emqx_auth_mongo, brutal_purge, soft_purge, []},
+       {load_module, emqx_acl_mongo, brutal_purge, soft_purge, [emqx_auth_mongo]}
+     ]}
+   ]
+}.

--- a/src/emqx_auth_mongo.erl
+++ b/src/emqx_auth_mongo.erl
@@ -40,9 +40,10 @@ register_metrics() ->
     lists:foreach(fun emqx_metrics:ensure/1, ?AUTH_METRICS).
 
 check(ClientInfo = #{password := Password}, AuthResult,
-      #{authquery := AuthQuery, superquery := SuperQuery, pool := Pool}) ->
+      Env = #{authquery := AuthQuery, superquery := SuperQuery}) ->
     #authquery{collection = Collection, field = Fields,
                hash = HashType, selector = Selector} = AuthQuery,
+    Pool = maps:get(pool, Env, ?APP),
     case query(Pool, Collection, maps:from_list(replvars(Selector, ClientInfo))) of
         undefined -> emqx_metrics:inc(?AUTH_METRICS(ignore));
         {error, Reason} ->

--- a/src/emqx_auth_mongo.erl
+++ b/src/emqx_auth_mongo.erl
@@ -123,8 +123,11 @@ query(Pool, Collection, Selector) ->
 query_multi(Pool, Collection, SelectorList) ->
     lists:reverse(lists:flatten(lists:foldl(fun(Selector, Acc1) ->
         Batch = ecpool:with_client(Pool, fun(Conn) ->
-                  {ok, Cursor} = mongo_api:find(Conn, Collection, Selector, #{}),
-                  mc_cursor:foldl(fun(O, Acc2) -> [O|Acc2] end, [], Cursor, 1000)
+                  case mongo_api:find(Conn, Collection, Selector, #{}) of
+                      [] -> [];
+                      {ok, Cursor} ->
+                          mc_cursor:foldl(fun(O, Acc2) -> [O|Acc2] end, [], Cursor, 1000)
+                  end
                 end),
         [Batch|Acc1]
     end, [], SelectorList))).

--- a/src/emqx_auth_mongo.erl
+++ b/src/emqx_auth_mongo.erl
@@ -31,8 +31,8 @@
 -export([ replvar/2
         , replvars/2
         , connect/1
-        , query/2
-        , query_multi/2
+        , query/3
+        , query_multi/3
         ]).
 
 -spec(register_metrics() -> ok).
@@ -40,10 +40,10 @@ register_metrics() ->
     lists:foreach(fun emqx_metrics:ensure/1, ?AUTH_METRICS).
 
 check(ClientInfo = #{password := Password}, AuthResult,
-      #{authquery := AuthQuery, superquery := SuperQuery}) ->
+      #{authquery := AuthQuery, superquery := SuperQuery, pool := Pool}) ->
     #authquery{collection = Collection, field = Fields,
                hash = HashType, selector = Selector} = AuthQuery,
-    case query(Collection, maps:from_list(replvars(Selector, ClientInfo))) of
+    case query(Pool, Collection, maps:from_list(replvars(Selector, ClientInfo))) of
         undefined -> emqx_metrics:inc(?AUTH_METRICS(ignore));
         {error, Reason} ->
             ?LOG(error, "[MongoDB] Can't connect to MongoDB server: ~0p", [Reason]),
@@ -60,7 +60,7 @@ check(ClientInfo = #{password := Password}, AuthResult,
             case Result of
                 ok ->
                     ok = emqx_metrics:inc(?AUTH_METRICS(success)),
-                    {stop, AuthResult#{is_superuser => is_superuser(SuperQuery, ClientInfo),
+                    {stop, AuthResult#{is_superuser => is_superuser(Pool, SuperQuery, ClientInfo),
                                        anonymous => false,
                                        auth_result => success}};
                 {error, Error} ->
@@ -82,11 +82,11 @@ description() -> "Authentication with MongoDB".
 %% Is Superuser?
 %%--------------------------------------------------------------------
 
--spec(is_superuser(maybe(#superquery{}), emqx_types:clientinfo()) -> boolean()).
-is_superuser(undefined, _ClientInfo) ->
+-spec(is_superuser(string(), maybe(#superquery{}), emqx_types:clientinfo()) -> boolean()).
+is_superuser(_Pool, undefined, _ClientInfo) ->
     false;
-is_superuser(#superquery{collection = Coll, field = Field, selector = Selector}, ClientInfo) ->
-    Row = query(Coll, maps:from_list(replvars(Selector, ClientInfo))),
+is_superuser(Pool, #superquery{collection = Coll, field = Field, selector = Selector}, ClientInfo) ->
+    Row = query(Pool, Coll, maps:from_list(replvars(Selector, ClientInfo))),
     case maps:get(Field, Row, false) of
         true   -> true;
         _False -> false
@@ -117,12 +117,12 @@ connect(Opts) ->
     WorkerOptions = proplists:get_value(worker_options, Opts, []),
     mongo_api:connect(Type, Hosts, Options, WorkerOptions).
 
-query(Collection, Selector) ->
-    ecpool:with_client(?APP, fun(Conn) -> mongo_api:find_one(Conn, Collection, Selector, #{}) end).
+query(Pool, Collection, Selector) ->
+    ecpool:with_client(Pool, fun(Conn) -> mongo_api:find_one(Conn, Collection, Selector, #{}) end).
 
-query_multi(Collection, SelectorList) ->
+query_multi(Pool, Collection, SelectorList) ->
     lists:foldr(fun(Selector, Acc) ->
-        case query(Collection, Selector) of
+        case query(Pool, Collection, Selector) of
             undefined -> Acc;
             Result -> [Result|Acc]
         end

--- a/src/emqx_auth_mongo_app.erl
+++ b/src/emqx_auth_mongo_app.erl
@@ -52,11 +52,11 @@ reg_authmod(AuthQuery) ->
     emqx_auth_mongo:register_metrics(),
     SuperQuery = r(super_query, application:get_env(?APP, super_query, undefined)),
     ok = emqx:hook('client.authenticate', fun emqx_auth_mongo:check/3,
-                   [#{authquery => AuthQuery, superquery => SuperQuery}]).
+                   [#{authquery => AuthQuery, superquery => SuperQuery, pool => ?APP}]).
 
 reg_aclmod(AclQuery) ->
     emqx_acl_mongo:register_metrics(),
-    ok = emqx:hook('client.check_acl', fun emqx_acl_mongo:check_acl/5, [#{aclquery => AclQuery}]).
+    ok = emqx:hook('client.check_acl', fun emqx_acl_mongo:check_acl/5, [#{aclquery => AclQuery, pool => ?APP}]).
 
 %%--------------------------------------------------------------------
 %% Internal functions


### PR DESCRIPTION
1. Use the dynamic ecpool name instead of the hardcode application name
2. Fix the multiple ACL selector queries, e.g:

```
auth.mongo.acl_query.selector.1 = username=%u
auth.mongo.acl_query.selector.2 = username=$all
```